### PR TITLE
Replacing flatMap With compactMap

### DIFF
--- a/Sources/InnerAlertController.swift
+++ b/Sources/InnerAlertController.swift
@@ -241,7 +241,7 @@ class InnerAlertController: UIAlertController {
     
     private func searchLabel(from text: String) -> UILabel? {
         return view.recursiveSubviews
-            .flatMap { $0 as? UILabel}
+            .compactMap { $0 as? UILabel}
             .first { $0.text == text }
     }
     


### PR DESCRIPTION
flatMap is mark as deprecated in Swift 4.1 and replaced by compactMap