### PR TITLE
Update how_to_use.md

### DIFF
--- a/Documents/how_to_use.md
+++ b/Documents/how_to_use.md
@@ -14,7 +14,7 @@ Alertift.alert(title: "Sample 1", message: "Simple alert!")
 
 ```swift
 Alertift.alert(title: "Confirm", message: "Delete this post?")
-    .action(.destructive("Delete")) { _ in
+    .action(.destructive("Delete")) { _, _, _ in
         // delete post
     }
     .action(.cancel("Cancel"))


### PR DESCRIPTION
```
Cannot convert value of type '(_) -> UIViewController?' to expected argument type 'Alertift.Alert.Handler?' (aka 'Optional<(UIAlertAction, Int, Optional<Array<UITextField>>) -> ()>')
```