### PR TITLE
Added `ShortHandler`

### DIFF
--- a/Alertift.podspec
+++ b/Alertift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Alertift"
-  s.version          = "4.1"
+  s.version          = "4.1.1"
   s.summary          = "UIAlertControlelr wrapper for Swift."
   s.homepage         = "https://github.com/sgr-ksmt/Alertift"
   # s.screenshots     = ""

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -75,12 +75,12 @@ class ViewController: UIViewController {
     
     private func showYesOrNoAlert() {
         Alertift.alert(title: "Sample 2",message: "Do you like 🍣?")
-            .action(.default("Yes"), isPreferred: true) { (_, _, _) in
+            .action(.default("Yes"), isPreferred: true) {
                 Alertift.alert(message: "🍣🍣🍣")
                     .action(.default("Close"))
                     .show()
             }
-            .action(.cancel("No")) { (_, _, _) in
+            .action(.cancel("No")) {
                 Alertift.alert(message: "😂😂😂")
                     .action(.destructive("Close"))
                     .show()

--- a/Documents/how_to_use.md
+++ b/Documents/how_to_use.md
@@ -14,7 +14,7 @@ Alertift.alert(title: "Sample 1", message: "Simple alert!")
 
 ```swift
 Alertift.alert(title: "Confirm", message: "Delete this post?")
-    .action(.destructive("Delete")) { _, _, _ in
+    .action(.destructive("Delete")) {
         // delete post
     }
     .action(.cancel("Cancel"))

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Alertift.alert(title: "Alertift", message: "Alertift is swifty, modern, and awes
 
 ## Requirements
 - iOS 9.0+
-- Xcode 8.1+
-- Swift 3.0+
+- Xcode 10+
+- Swift 5.0+
 
 ## Installation
 
@@ -80,9 +80,6 @@ and run `pod install`
 
 ### Manually Install
 Download all `*.swift` files and put your project.
-
-## Change log
-Change log is [here](https://github.com/sgr-ksmt/Alertift/blob/master/CHANGELOG.md).
 
 ## Communication
 - If you found a bug, open an issue.

--- a/Sources/ActionSheet.swift
+++ b/Sources/ActionSheet.swift
@@ -34,17 +34,17 @@ extension Alertift {
         }
         
         /// Add action to alertController
-        public func action(_ action: Alertift.Action, handler: Handler? = nil) -> Self {
+        public func action(_ action: Alertift.Action, handler: Handler?) -> Self {
             return self.action(action, image: nil, handler: handler)
         }
 
-        public func action(_ action: Alertift.Action, handler: ShortHandler?) -> Self {
+        public func action(_ action: Alertift.Action, handler: ShortHandler? = nil) -> Self {
             return self.action(action) { _, _ in handler?() }
         }
 
 
         /// Add action to alertController
-        public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, handler: Handler? = nil) -> Self {
+        public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, handler: Handler?) -> Self {
             let alertAction = buildAlertAction(action, handler:
                 merge(_alertController.actionHandler, handler ?? { (_, _) in })
             )

--- a/Sources/ActionSheet.swift
+++ b/Sources/ActionSheet.swift
@@ -11,7 +11,6 @@ import Foundation
 extension Alertift {
     /// ActionSheet
     final public class ActionSheet: AlertType, _AlertType {
-
         public typealias Handler = (UIAlertAction, Int) -> Void
 
         var _alertController: InnerAlertController!
@@ -39,6 +38,11 @@ extension Alertift {
             return self.action(action, image: nil, handler: handler)
         }
 
+        public func action(_ action: Alertift.Action, handler: ShortHandler?) -> Self {
+            return self.action(action) { _, _ in handler?() }
+        }
+
+
         /// Add action to alertController
         public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, handler: Handler? = nil) -> Self {
             let alertAction = buildAlertAction(action, handler:
@@ -51,6 +55,10 @@ extension Alertift {
 
             _alertController.addAction(alertAction)
             return self
+        }
+
+        public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, handler: ShortHandler? = nil) -> Self {
+            return self.action(action, image: image, renderingMode: renderingMode) { _, _ in handler?() }
         }
                 
         /// Add sourceView and sourceRect to **popoverPresentationController**.

--- a/Sources/Alert.swift
+++ b/Sources/Alert.swift
@@ -45,7 +45,7 @@ extension Alertift {
             buildAlertControlelr(title: title, message: message, style: .alert)
         }
         
-        public func action(_ action: Alertift.Action, handler: Handler? = nil) -> Self {
+        public func action(_ action: Alertift.Action, handler: Handler?) -> Self {
             return self.action(action, isPreferred: false, handler: handler)
         }
 
@@ -59,7 +59,7 @@ extension Alertift {
         ///   - isPreferred: If you want to change this action to preferredAction, set true. Default is false.
         ///   - handler: The block to execute after this action performed.
         /// - Returns: Myself
-        public func action(_ action: Alertift.Action, isPreferred: Bool, handler: Handler? = nil) -> Self {
+        public func action(_ action: Alertift.Action, isPreferred: Bool, handler: Handler?) -> Self {
             return self.action(action, image: nil, isPreferred: isPreferred, handler: handler)
         }
 
@@ -75,7 +75,7 @@ extension Alertift {
         ///   - renderMode: Render mode for alert action image. Default is `.automatic`
         ///   - handler: The block to execute after this action performed.
         /// - Returns: Myself
-        public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, handler: Handler? = nil) -> Self {
+        public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, handler: Handler?) -> Self {
             return self.action(action, image: image, renderingMode: renderingMode, isPreferred: false, handler: handler)
         }
 
@@ -92,7 +92,7 @@ extension Alertift {
         ///   - isPreferred: If you want to change this action to preferredAction, set true. Default is false.
         ///   - handler: The block to execute after this action performed.
         /// - Returns: Myself
-        public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, isPreferred: Bool, handler: Handler? = nil) -> Self {
+        public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, isPreferred: Bool, handler: Handler?) -> Self {
             let alertAction = buildAlertAction(
                 action,
                 handler: merge(_alertController.actionWithTextFieldsHandler, handler ?? { (_, _, _)in })

--- a/Sources/Alert.swift
+++ b/Sources/Alert.swift
@@ -49,6 +49,9 @@ extension Alertift {
             return self.action(action, isPreferred: false, handler: handler)
         }
 
+        public func action(_ action: Alertift.Action, handler: ShortHandler? = nil) -> Self {
+            return self.action(action) { _, _, _ in handler?() }
+        }
         /// Add action to Alert
         ///
         /// - Parameters:
@@ -58,6 +61,10 @@ extension Alertift {
         /// - Returns: Myself
         public func action(_ action: Alertift.Action, isPreferred: Bool, handler: Handler? = nil) -> Self {
             return self.action(action, image: nil, isPreferred: isPreferred, handler: handler)
+        }
+
+        public func action(_ action: Alertift.Action, isPreferred: Bool, handler: ShortHandler? = nil) -> Self {
+            return self.action(action, image: nil, isPreferred: isPreferred) { _, _, _ in handler?() }
         }
 
         /// Add action to Alert
@@ -70,6 +77,10 @@ extension Alertift {
         /// - Returns: Myself
         public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, handler: Handler? = nil) -> Self {
             return self.action(action, image: image, renderingMode: renderingMode, isPreferred: false, handler: handler)
+        }
+
+        public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, handler: ShortHandler? = nil) -> Self {
+            return self.action(action, image: image, renderingMode: renderingMode, isPreferred: false) { _, _, _ in handler?() }
         }
 
         /// Add action to Alert
@@ -93,6 +104,10 @@ extension Alertift {
 
             addActionToAlertController(alertAction, isPreferred: isPreferred)
             return self
+        }
+
+        public func action(_ action: Alertift.Action, image: UIImage?, renderingMode: UIImage.RenderingMode = .automatic, isPreferred: Bool, handler: ShortHandler? = nil) -> Self {
+            return self.action(action, image: image, renderingMode: renderingMode, isPreferred: isPreferred) { _, _, _ in handler?() }
         }
 
         /// Add text field to alertController

--- a/Sources/AlertType.swift
+++ b/Sources/AlertType.swift
@@ -29,6 +29,7 @@ extension _AlertType where Self: AlertType {
 /// AlertType protocol
 public protocol AlertType: class {
     associatedtype Handler
+    typealias ShortHandler = () -> Void
 
     /// Add action to Alert
     ///
@@ -37,7 +38,15 @@ public protocol AlertType: class {
     ///   - handler: The block to execute after this action performed.
     /// - Returns: Myself
     func action(_ action: Alertift.Action, handler: Handler?) -> Self
-    
+
+    /// Add action to Alert
+    ///
+    /// - Parameters:
+    ///   - action: Alert action.
+    ///   - handler: The block to execute after this action performed.
+    /// - Returns: Myself
+    func action(_ action: Alertift.Action, handler: ShortHandler?) -> Self
+
     /// UIAlertController
     var alertController: UIAlertController { get }
     /// default background color of Alert(ActionSheet).


### PR DESCRIPTION
I just implemented `ShortHandler`. 
By using this `ShortHandler`, it is possible to avoid writing `(_, _, _) in closure if you don't use closure arguments.

## Before

```swift
Alertift.alert(title: "Sample 2",message: "Do you like 🍣?")
    .action(.default("Yes"), isPreferred: true) { _, _, _ in
        Alertift.alert(message: "🍣🍣🍣")
            .action(.default("Close"))
            .show()
    }
    .action(.cancel("No")) { _, _, _ in
        Alertift.alert(message: "😂😂😂")
            .action(.destructive("Close"))
            .show()
    }
    .show()
```

## After

```swift
Alertift.alert(title: "Sample 2",message: "Do you like 🍣?")
    .action(.default("Yes"), isPreferred: true) {
        Alertift.alert(message: "🍣🍣🍣")
            .action(.default("Close"))
            .show()
    }
    .action(.cancel("No")) {
        Alertift.alert(message: "😂😂😂")
            .action(.destructive("Close"))
            .show()
    }
    .show()
```

## Diff

```diff
+     .action(.default("Yes"), isPreferred: true) {
-     .action(.default("Yes"), isPreferred: true) { _, _, _ in
```